### PR TITLE
Update for HX711 v0.7.2

### DIFF
--- a/firmware/SparkFun_HX711_Calibration/SparkFun_HX711_Calibration.ino
+++ b/firmware/SparkFun_HX711_Calibration/SparkFun_HX711_Calibration.ino
@@ -38,7 +38,7 @@
 #define DOUT  3
 #define CLK  2
 
-HX711 scale(DOUT, CLK);
+HX711 scale;
 
 float calibration_factor = -7050; //-7050 worked for my 440lb max scale setup
 
@@ -50,6 +50,7 @@ void setup() {
   Serial.println("Press + or a to increase calibration factor");
   Serial.println("Press - or z to decrease calibration factor");
 
+  scale.begin(DOUT, CLK);
   scale.set_scale();
   scale.tare();	//Reset the scale to 0
 

--- a/firmware/SparkFun_HX711_Example/SparkFun_HX711_Example.ino
+++ b/firmware/SparkFun_HX711_Example/SparkFun_HX711_Example.ino
@@ -30,12 +30,13 @@
 #define DOUT  3
 #define CLK  2
 
-HX711 scale(DOUT, CLK);
+HX711 scale;
 
 void setup() {
   Serial.begin(9600);
   Serial.println("HX711 scale demo");
 
+  scale.begin(DOUT, CLK);
   scale.set_scale(calibration_factor); //This value is obtained by using the SparkFun_HX711_Calibration sketch
   scale.tare();	//Assuming there is no weight on the scale at start up, reset the scale to 0
 

--- a/firmware/SparkFun_HX711_KnownZeroStartup/SparkFun_HX711_KnownZeroStartup.ino
+++ b/firmware/SparkFun_HX711_KnownZeroStartup/SparkFun_HX711_KnownZeroStartup.ino
@@ -32,12 +32,13 @@
 #define DOUT  3
 #define CLK  2
 
-HX711 scale(DOUT, CLK);
+HX711 scale;
 
 void setup() {
   Serial.begin(9600);
   Serial.println("Demo of zeroing out a scale from a known value");
 
+  scale.begin(DOUT, CLK);
   scale.set_scale(calibration_factor); //This value is obtained by using the SparkFun_HX711_Calibration sketch
   scale.set_offset(zero_factor); //Zero out the scale using a previously known zero_factor
 

--- a/firmware/SparkFun_HX711_PowerTest/SparkFun_HX711_PowerTest.ino
+++ b/firmware/SparkFun_HX711_PowerTest/SparkFun_HX711_PowerTest.ino
@@ -32,12 +32,13 @@
 #define DOUT  3
 #define CLK  2
 
-HX711 scale(DOUT, CLK);
+HX711 scale;
 
 void setup() {
   Serial.begin(9600);
   Serial.println("HX711 power test");
 
+  scale.begin(DOUT, CLK);
   scale.set_scale(calibration_factor); //This value is obtained by using the SparkFun_HX711_Calibration sketch
   scale.set_offset(zero_factor); //Zero out the scale using a previously known zero_factor
 


### PR DESCRIPTION
The HX711 library now only has a default constructor, begin() must
be used to initialize DOUT, PD_SCK and GAIN.